### PR TITLE
Differentiate between CSS and JS MIME type

### DIFF
--- a/server.js
+++ b/server.js
@@ -33,7 +33,7 @@ http.createServer(function (req, res) {
     var filename = dir + pathname;
     var stats = fs.existsSync(filename) && fs.statSync(filename);
     if (stats && stats.isFile()) {
-      res.writeHead(200, {'Content-Type' : 'text/css'});
+      res.writeHead(200, {'Content-Type': m[1] == 'css' ? 'text/css' : 'application/javascript'});
       fs.createReadStream(filename).pipe(res);
       return;
     }


### PR DESCRIPTION
Incorrect mimetype was causing `importScripts('image-helper.js');` at [worker.js:2](https://github.com/gustavomazzoni/photo-mosaic/blob/master/js/worker.js) to fail.

This is probably the reason issue #1 was created although that issue doesn't provide any feedback.